### PR TITLE
Deploy with heroku and netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## Live Demo
 
 [Live Demo Link](https://yayner-react-calculator-app.herokuapp.com/)
+[Live Demo Link](https://yayner-react-calculator-app.netlify.app/)
 
 ## Screenshot
 ![home page](app_screenshot.png?raw=true "home screenshot")

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - React
 ## Live Demo
 
-[Live Demo Link](https://yayner2002.github.io/react-math-magicians/)
+[Live Demo Link](https://yayner-react-calculator-app.herokuapp.com/)
 
 ## Screenshot
 ![home page](app_screenshot.png?raw=true "home screenshot")


### PR DESCRIPTION
in this PR the following features were implemented

- Use Heroku to deploy the Math Magicians app.
- Use Netlify to deploy the Math Magicians app.
- Add 2 links to the deployed applications (Heroku and Netlify) to the README file in your GitHub repo.